### PR TITLE
Sync functions were not properly emitting errors if they throwed

### DIFF
--- a/interfaces/chai.js
+++ b/interfaces/chai.js
@@ -4,7 +4,8 @@ declare module 'chai' {
     deep: ChaiAssertion,
     be: ChaiAssertion,
     an: ChaiAssertion,
-    itself: ChaiAssertion
+    itself: ChaiAssertion,
+    have: ChaiAssertion
   }
 
   declare type ChaiAssertion = LanguageChain & {
@@ -13,7 +14,8 @@ declare module 'chai' {
     true: void,
     equal: (value: mixed, message?: string) => void,
     respondTo: (method: string, message?: string) => void,
-    instanceOf: (type: any, message?: string) => void
+    instanceOf: (type: any, message?: string) => void,
+    property: (property: string, value: any) => void
   }
 
   declare var exports: {

--- a/lib/index.js
+++ b/lib/index.js
@@ -168,7 +168,11 @@ class ReadSyncStream extends Readable {
   }
 
   _read () {
-    this._fn(this.push.bind(this))
+    try {
+      this._fn(this.push.bind(this))
+    } catch (err) {
+      return this.emit('error', err)
+    }
     this.push(null)
   }
 }
@@ -187,7 +191,11 @@ class MapSyncStream<T> extends Transform {
   }
 
   _transform (chunk: any, encoding: string, callback: (err: ?Error, val: any) => void) {
-    callback(null, this._fn(chunk))
+    try {
+      callback(null, this._fn(chunk))
+    } catch (err) {
+      callback(err)
+    }
   }
 }
 
@@ -303,8 +311,12 @@ class FilterSyncStream extends Transform {
   }
 
   _transform (chunk: any, encoding: string, callback: () => void) {
-    if (this._fn(chunk)) this.push(chunk)
-    callback()
+    try {
+      if (this._fn(chunk)) this.push(chunk)
+      callback()
+    } catch (err) {
+      callback(err)
+    }
   }
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -127,6 +127,22 @@ describe('stream-util specs', function () {
     return promise
   })
 
+  it('should emit a thrown error when reading sync', (done) => {
+    const readFunc = () => {
+      throw new Error('foo')
+    }
+    const errorHandler = (error) => {
+      expect(error).to.have.property('message', 'foo')
+      done()
+    }
+    const endHandler = () => done(new Error('should not call end'))
+
+    const stream = readSync(readFunc)
+    stream.on('error', errorHandler).on('end', endHandler)
+
+    stream.resume()
+  })
+
   it('should map async', () => {
     const src = ['1', '2']
     const mapping = (it: string) => `${it}:foo`
@@ -158,6 +174,23 @@ describe('stream-util specs', function () {
       .pipe(transform)
 
     return promise
+  })
+
+  it('should emit the thrown error when mapping sync', (done) => {
+    const src = ['1', '2']
+    const mapping = () => {
+      throw new Error('foo')
+    }
+    const errorHandler = (error) => {
+      expect(error).to.have.property('message', 'foo')
+      done()
+    }
+    const endHandler = () => done(new Error('Should not call end'))
+
+    fromArray(src)
+      .pipe(mapSync(mapping))
+      .on('error', errorHandler)
+      .on('end', endHandler)
   })
 
   it('should through async', () => {
@@ -224,6 +257,23 @@ describe('stream-util specs', function () {
       .pipe(transform)
 
     return promise
+  })
+
+  it('should emit the thrown error when running filter sync', (done) => {
+    const src = [1, 2, 3]
+    const filterFn = () => {
+      throw new Error('foo')
+    }
+    const errorHandler = (error) => {
+      expect(error).to.have.property('message', 'foo')
+      done()
+    }
+    const endHandler = () => done(new Error('should not call end'))
+
+    fromArray(src)
+      .pipe(filterSync(filterFn))
+      .on('error', errorHandler)
+      .on('end', endHandler)
   })
 
   it('should promisify a stream', () => {


### PR DESCRIPTION
This made long streaming pipelines difficult to debug.

I had a very quick look at `consume`, but can't say I fully grasp it yet.
Are streams you pipe the consumed readable into automatically added to the domain? (if so, then it's a really clever hack :-) )
```javascript
streamUtil.consume(myReadable)
  .pipe(someProcessing)
  .pipe(myWritable)
  .on('error', myErrorHandler);
```